### PR TITLE
feat: openai 2.31.0 and readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,17 @@ jupyter-repo2docker --user-id=1000 --user-name=jovyan \
   . # <--- the path to the repo
 ```
 
+If you hit `OMP: Error #13` / `kmp_affinity.cpp` when running on Apple Silicon (especially on low-memory or resource-constrained machines), run with conservative OpenMP settings:
+
+``` bash
+jupyter-repo2docker --user-id=1000 --user-name=jovyan \
+  --Repo2Docker.platform=linux/amd64 \
+  --target-repo-dir=/home/jovyan/.cache \
+  -e PLAYWRIGHT_BROWSERS_PATH=/srv/conda \
+  -e KMP_AFFINITY=disabled \
+  -e OMP_NUM_THREADS=1 \
+  -e KMP_INIT_AT_FORK=FALSE \
+  . 
+```
+
 If you just want to see if the image builds, but not automatically launch the server, add `--no-run` to the arguments (before the final `.`).

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - pip:
     # AI/ML
     - gpt4all==2.8.2
-    - openai==2.6.1
+    - openai==2.31.0
     - gradio==5.49.1
     - anthropic==0.83.0
     - python-dotenv==1.2.1


### PR DESCRIPTION
Upgrade `openai` to 2.31.0 with an additional note on the `README.md` on how to run `repo2docker` with a resource-constrained Mac 😅.