### PR TITLE
feat: upgrade jupytutor and include ipywidgets

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   # data science
   - huggingface_hub==1.4.1
   - llama-cpp-python==0.3.16
+  - ipywidgets==8.1.8
 
   # pip installed packages, conda is preferred
   - pip:
@@ -26,4 +27,4 @@ dependencies:
     - google-genai==1.60.0
     - polars[all]==1.39.0
 
-    - jupytutor==0.4.0
+    - jupytutor==0.4.1


### PR DESCRIPTION
Jupytutor 0.4.1 is hub agnostic, so it now works with the workshop hub.

Ipywidgets for an ECC Modules notebook demo that uses ipywidgets to simulate the AI trolley problem animation.